### PR TITLE
Fix devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://containers.dev
 {
 	"name": "csi-driver-image dev container",
-	"image": "ghcr.io/warm-metal/csi-driver-image/devcontainer:latest",
+	"image": "ghcr.io/mbtamuli/container-image-csi-driver/devcontainer:latest",
 
 	// Setup the go environment and mount into the dev container at the expected location
 	"workspaceFolder": "/go/src/github.com/warm-metal/csi-driver-image",

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 // For format details, see https://containers.dev
 {
 	"name": "csi-driver-image dev container",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"build": {
+		"dockerfile": "./Dockerfile",
+		"context": "."
+	},
 
 	"otherPortsAttributes": {
 		"onAutoForward": "silent"

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 // For format details, see https://containers.dev
 {
 	"name": "csi-driver-image dev container",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-	//"build": {
-	//	"dockerfile": "./Dockerfile",
-	//	"context": "."
-	//},
+	//"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"build": {
+		"dockerfile": "./Dockerfile",
+		"context": "."
+	},
 	"otherPortsAttributes": {
 		"onAutoForward": "silent"
 	},

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 // For format details, see https://containers.dev
 {
 	"name": "csi-driver-image dev container",
-	"build": {
-		"dockerfile": "./Dockerfile",
-		"context": "."
-	},
-
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	//"build": {
+	//	"dockerfile": "./Dockerfile",
+	//	"context": "."
+	//},
 	"otherPortsAttributes": {
 		"onAutoForward": "silent"
 	},

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,11 +1,15 @@
 // For format details, see https://containers.dev
 {
 	"name": "csi-driver-image dev container",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-	//"build": {
-	//	"dockerfile": "./Dockerfile",
-	//	"context": "."
-	//},
+	// Workaround as mentioned in
+	// https://github.com/devcontainers/ci/issues/191#issuecomment-1473518609
+
+	//"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"build": {
+		"dockerfile": "./Dockerfile",
+		"context": "."
+	},
+
 	"otherPortsAttributes": {
 		"onAutoForward": "silent"
 	},

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 // For format details, see https://containers.dev
 {
 	"name": "csi-driver-image dev container",
-	//"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-	"build": {
-		"dockerfile": "./Dockerfile",
-		"context": "."
-	},
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	//"build": {
+	//	"dockerfile": "./Dockerfile",
+	//	"context": "."
+	//},
 	"otherPortsAttributes": {
 		"onAutoForward": "silent"
 	},

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -35,6 +35,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3.1900000339
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: true
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -16,7 +16,57 @@ permissions:
   packages: write
 
 jobs:
-  build-and-push-image-amd64:
+  #build-and-push-image-amd64:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - name: Checkout repository
+  #      uses: actions/checkout@v4
+  #    - name: Set up QEMU
+  #      uses: docker/setup-qemu-action@v3
+  #      with:
+  #        platforms: linux/amd64
+  #    - name: Set up Docker Buildx
+  #      uses: docker/setup-buildx-action@v3
+  #    - name: Log in to the GitHub Container registry
+  #      uses: docker/login-action@v3
+  #      with:
+  #        registry: ghcr.io
+  #        username: ${{ github.repository_owner }}
+  #        password: ${{ secrets.GITHUB_TOKEN }}
+  #    - name: Pre-build dev container image
+  #      uses: devcontainers/ci@v0.3
+  #      with:
+  #        subFolder: .github
+  #        imageName: ghcr.io/${{ github.repository }}/devcontainer
+  #        cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+  #        platform: linux/amd64
+  #        push: always
+  #build-and-push-image-arm64:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - name: Checkout repository
+  #      uses: actions/checkout@v4
+  #    - name: Set up QEMU
+  #      uses: docker/setup-qemu-action@v3
+  #      with:
+  #        platforms: linux/arm64
+  #    - name: Set up Docker Buildx
+  #      uses: docker/setup-buildx-action@v3
+  #    - name: Log in to the GitHub Container registry
+  #      uses: docker/login-action@v3
+  #      with:
+  #        registry: ghcr.io
+  #        username: ${{ github.repository_owner }}
+  #        password: ${{ secrets.GITHUB_TOKEN }}
+  #    - name: Pre-build dev container image
+  #      uses: devcontainers/ci@v0.3
+  #      with:
+  #        subFolder: .github
+  #        imageName: ghcr.io/${{ github.repository }}/devcontainer
+  #        cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+  #        platform: linux/arm64
+  #        push: always
+  build-and-push-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,7 +74,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to the GitHub Container registry
@@ -34,35 +84,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build dev container image
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@v0.3.1900000339
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer
           cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-          platform: linux/amd64
-          push: always
-  build-and-push-image-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pre-build dev container image
-        uses: devcontainers/ci@v0.3
-        with:
-          subFolder: .github
-          imageName: ghcr.io/${{ github.repository }}/devcontainer
-          cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-          platform: linux/arm64
+          platform: linux/amd64,linux/arm64
           push: always

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -34,9 +34,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build dev container image
-        uses: devcontainers/ci@v0.3.1900000339
-        env:
-          BUILDX_NO_DEFAULT_ATTESTATIONS: true
+        uses: devcontainers/ci@v0.3
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -35,5 +35,5 @@ jobs:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer
           cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-          platform: linux/amd64, linux/arm64
+          platform: linux/amd64,linux/arm64
           push: always

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -21,14 +21,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3
         with:

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -16,56 +16,6 @@ permissions:
   packages: write
 
 jobs:
-  #build-and-push-image-amd64:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Checkout repository
-  #      uses: actions/checkout@v4
-  #    - name: Set up QEMU
-  #      uses: docker/setup-qemu-action@v3
-  #      with:
-  #        platforms: linux/amd64
-  #    - name: Set up Docker Buildx
-  #      uses: docker/setup-buildx-action@v3
-  #    - name: Log in to the GitHub Container registry
-  #      uses: docker/login-action@v3
-  #      with:
-  #        registry: ghcr.io
-  #        username: ${{ github.repository_owner }}
-  #        password: ${{ secrets.GITHUB_TOKEN }}
-  #    - name: Pre-build dev container image
-  #      uses: devcontainers/ci@v0.3
-  #      with:
-  #        subFolder: .github
-  #        imageName: ghcr.io/${{ github.repository }}/devcontainer
-  #        cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-  #        platform: linux/amd64
-  #        push: always
-  #build-and-push-image-arm64:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Checkout repository
-  #      uses: actions/checkout@v4
-  #    - name: Set up QEMU
-  #      uses: docker/setup-qemu-action@v3
-  #      with:
-  #        platforms: linux/arm64
-  #    - name: Set up Docker Buildx
-  #      uses: docker/setup-buildx-action@v3
-  #    - name: Log in to the GitHub Container registry
-  #      uses: docker/login-action@v3
-  #      with:
-  #        registry: ghcr.io
-  #        username: ${{ github.repository_owner }}
-  #        password: ${{ secrets.GITHUB_TOKEN }}
-  #    - name: Pre-build dev container image
-  #      uses: devcontainers/ci@v0.3
-  #      with:
-  #        subFolder: .github
-  #        imageName: ghcr.io/${{ github.repository }}/devcontainer
-  #        cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-  #        platform: linux/arm64
-  #        push: always
   build-and-push-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -16,7 +16,7 @@ permissions:
   packages: write
 
 jobs:
-  build-and-push-image:
+  build-and-push-image-amd64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,7 +24,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to the GitHub Container registry
@@ -39,5 +39,30 @@ jobs:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer
           cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-          platform: linux/amd64,linux/arm64
+          platform: linux/amd64
+          push: always
+  build-and-push-image-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-build dev container image
+        uses: devcontainers/ci@v0.3
+        with:
+          subFolder: .github
+          imageName: ghcr.io/${{ github.repository }}/devcontainer
+          cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+          platform: linux/arm64
           push: always

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -35,4 +35,5 @@ jobs:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer
           cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
+          platform: linux/amd64, linux/arm64
           push: always

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to the GitHub Container registry
@@ -32,7 +34,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build dev container image
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@v0.3.1900000339
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -83,8 +83,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install updated skopeo
+        run: |
+          sudo apt purge buildah golang-github-containers-common podman skopeo
+          sudo apt autoremove --purge
+          REPO_URL="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable"
+          source /etc/os-release
+          sudo sh -c "echo 'deb ${REPO_URL}/x${NAME}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          sudo wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
+          sudo apt-key add Release.key
+          sudo apt-get update
+          sudo apt-get install skopeo
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3.1900000339
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: true
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches: [main]
     paths:
-      - .github/workflows/devcontainer-build-and-push.yml
+      - .github/workflows/devcontainer-build-and-push.yaml
       - '.github/.devcontainer/**'
   pull_request:
     paths:
-      - .github/workflows/devcontainer-build-and-push.yml
+      - .github/workflows/devcontainer-build-and-push.yaml
       - '.github/.devcontainer/**'
 
 permissions:

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -34,6 +34,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install updated skopeo
+        # https://github.com/devcontainers/ci/issues/191#issuecomment-1416384710
         run: |
           sudo apt purge buildah golang-github-containers-common podman skopeo
           sudo apt autoremove --purge
@@ -43,7 +44,7 @@ jobs:
           sudo wget -qnv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${NAME}_${VERSION_ID}/Release.key -O Release.key
           sudo apt-key add Release.key
           sudo apt-get update
-          sudo apt-get install skopeo
+          sudo apt-get install skopeo -y
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3
         with:

--- a/.github/workflows/devcontainer-build-and-push.yaml
+++ b/.github/workflows/devcontainer-build-and-push.yaml
@@ -95,9 +95,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install skopeo
       - name: Pre-build dev container image
-        uses: devcontainers/ci@v0.3.1900000339
-        env:
-          BUILDX_NO_DEFAULT_ATTESTATIONS: true
+        uses: devcontainers/ci@v0.3
         with:
           subFolder: .github
           imageName: ghcr.io/${{ github.repository }}/devcontainer

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -3,7 +3,7 @@
 You have two options:
 
 1. Use the [Dev Container](#development-container). This is the recommended approach. This can be used with VSCode, the `devcontainer` CLI, or GitHub Codespaces.
-1. Install the [requirements](#requirements) on your computer manually.
+1. Install the [requirements](#requirements) on your computer manually. Once you have installed all the requirements, continue to [Developing Locally](#developing-locally).
 
 ## Development Container
 
@@ -22,13 +22,13 @@ Once you have entered the container, continue to [Developing Locally](#developin
 To build on your own machine without using the Dev Container you will need:
 
 * A local clone of this repository.
-* [Go](https://golang.org/dl/)
+* [Go](https://golang.org/dl/) - v1.19
 * A local Kubernetes cluster ([`k3d`](https://k3d.io/#quick-start), [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), or [`minikube`](https://minikube.sigs.k8s.io/docs/start/))
 * [`helm`](https://helm.sh/docs/intro/install/)
 
 ## Developing locally
 
-_**Note:** Unless specified otherwise, you need to run all commands after changing your working directory to this repository - `cd /path/to/container-image-csi-driver-repository`_
+_**Note:** Unless specified otherwise, you need to run all commands after changing your working directory to this repository, e.g. - `cd /path/to/container-image-csi-driver-repository`_
 
 1. First, make sure you can connect to the Kubernetes cluster by following the quickstart guide of your chosen local Kubernetes cluster provider.
   ```
@@ -47,3 +47,16 @@ _**Note:** Unless specified otherwise, you need to run all commands after changi
   ```bash
   kubectl create -f sample/ephemeral-volume.yaml
   ```
+
+### Running E2E tests locally
+
+#### Running One Test
+In most cases, you want to run the test that relates to your changes locally. You should not run all the tests suites. Our CI will run those concurrently when you create a PR, which will give you feedback much faster.
+
+Find the test that you want to run in test/e2e
+
+```
+make TestArtifactServer
+```
+
+#### Running A Set Of Tests


### PR DESCRIPTION
At least on my laptop, the devcontainer doesn't allow creating a Kind cluster.

```
kind create cluster
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.27.3) 🖼 
 ✗ Preparing nodes 📦  
Deleted nodes: ["kind-control-plane"]
ERROR: failed to create cluster: command "docker run --name kind-control-plane --hostname kind-control-plane --label io.x-k8s.kind.role=control-plane --privileged --security-opt seccomp=unconfined --security-opt apparmor=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro -e KIND_EXPERIMENTAL_CONTAINERD_SNAPSHOTTER --detach --tty --label io.x-k8s.kind.cluster=kind --net kind --restart=on-failure:1 --init=false --cgroupns=private --publish=127.0.0.1:38971:6443/TCP -e KUBECONFIG=/etc/kubernetes/admin.conf kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72" failed with error: exit status 125
Command Output: 343ee25c9a0f958af1d80c93a20141bec4822ff7f2827d54d3016bb57cffec3a
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: waiting for init preliminary setup: read init-p: connection reset by peer: unknown.
```

The changes in this PR is an attempt at fixing it.

References:
- https://github.com/devcontainers/ci/issues/191